### PR TITLE
feat: add new CI flag to the radar:scan command

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ Scan a different project path:
 php artisan radar:scan --path=/path/to/app
 ```
 
+Use CI mode in a pipeline after installing dependencies:
+
+```bash
+php artisan radar:scan --ci --severity=high
+```
+
+The `--ci` flag makes `radar:scan` return a failing status when vulnerabilities meet the configured severity threshold. Your CI provider does not need special handling. It only needs to run the command and respect the exit code.
+
+Set `--severity` to `low`, `medium`, `high`, or `critical`. Radar returns `1` when a vulnerability is at or above that threshold, `0` when none are, and `2` when the CI options or scan path are invalid.
+
 ### `radar:notify`
 
 Sends deduplicated vulnerability notifications for the latest stored scan.

--- a/src/Commands/ScanCommand.php
+++ b/src/Commands/ScanCommand.php
@@ -6,10 +6,15 @@ namespace JoshDonnell\Radar\Commands;
 
 use Illuminate\Console\Command;
 use JoshDonnell\Radar\Actions\RunScanAction;
+use JoshDonnell\Radar\Enums\VulnerabilitySeverity;
+use JoshDonnell\Radar\Support\CiScanReport;
 
 final class ScanCommand extends Command
 {
-    public $signature = 'radar:scan {--path= : Base path to scan. Defaults to the application base path}';
+    public $signature = 'radar:scan
+        {--path= : Base path to scan. Defaults to the application base path}
+        {--ci : Run in CI mode with pipeline friendly output and build failing exit codes}
+        {--severity=low : Minimum vulnerability severity that fails CI. Supported values: low, medium, high, critical}';
 
     public $description = 'Scan application dependencies and store a Radar snapshot';
 
@@ -21,13 +26,18 @@ final class ScanCommand extends Command
 
     public function handle(): int
     {
+        $ciMode = $this->option('ci') === true;
         $path = $this->option('path');
         $basepath = is_string($path) && $path !== '' ? $path : base_path();
 
         if (! is_dir($basepath)) {
             $this->components->error(sprintf('The path [%s] does not exist.', $basepath));
 
-            return self::FAILURE;
+            return $ciMode ? self::INVALID : self::FAILURE;
+        }
+
+        if ($ciMode) {
+            return $this->handleCiScan($basepath);
         }
 
         $scan = $this->runScan->execute($basepath);
@@ -46,5 +56,30 @@ final class ScanCommand extends Command
         ));
 
         return self::SUCCESS;
+    }
+
+    private function handleCiScan(string $basepath): int
+    {
+        $severity = $this->option('severity');
+        $severityThreshold = VulnerabilitySeverity::fromThreshold(
+            is_string($severity) && $severity !== ''
+                ? $severity
+                : VulnerabilitySeverity::Low->value,
+        );
+
+        if (! $severityThreshold instanceof VulnerabilitySeverity) {
+            $this->components->error(sprintf(
+                'Unsupported CI severity threshold. Supported severities are: %s.',
+                implode(', ', VulnerabilitySeverity::thresholdValues()),
+            ));
+
+            return self::INVALID;
+        }
+
+        $report = new CiScanReport($this->runScan->execute($basepath), $severityThreshold);
+
+        $this->output->writeln($report->lines());
+
+        return $report->exitCode();
     }
 }

--- a/src/Enums/VulnerabilitySeverity.php
+++ b/src/Enums/VulnerabilitySeverity.php
@@ -22,4 +22,42 @@ enum VulnerabilitySeverity: string
             default => self::Unknown,
         };
     }
+
+    public static function fromThreshold(?string $severity): ?self
+    {
+        return match (mb_strtolower((string) $severity)) {
+            'low' => self::Low,
+            'medium' => self::Medium,
+            'high' => self::High,
+            'critical' => self::Critical,
+            default => null,
+        };
+    }
+
+    /** @return list<string> */
+    public static function thresholdValues(): array
+    {
+        return [
+            self::Low->value,
+            self::Medium->value,
+            self::High->value,
+            self::Critical->value,
+        ];
+    }
+
+    public function meetsThreshold(self $threshold): bool
+    {
+        return $this->rank() >= $threshold->rank();
+    }
+
+    private function rank(): int
+    {
+        return match ($this) {
+            self::Unknown => 0,
+            self::Low => 1,
+            self::Medium => 2,
+            self::High => 3,
+            self::Critical => 4,
+        };
+    }
 }

--- a/src/Support/CiScanReport.php
+++ b/src/Support/CiScanReport.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JoshDonnell\Radar\Support;
+
+use JoshDonnell\Radar\Enums\VulnerabilitySeverity;
+use JoshDonnell\Radar\Models\RadarScan;
+
+final readonly class CiScanReport
+{
+    private string $severityThreshold;
+
+    private int $vulnerabilityCount;
+
+    /** @var list<string> */
+    private array $vulnerabilityLines;
+
+    private int $failingVulnerabilityCount;
+
+    public function __construct(RadarScan $scan, VulnerabilitySeverity $severityThreshold)
+    {
+        $vulnerabilities = $this->payloadList($scan, 'vulnerabilities');
+
+        $this->severityThreshold = $severityThreshold->value;
+        $this->vulnerabilityCount = count($vulnerabilities);
+        $this->vulnerabilityLines = array_map(
+            fn (array $vulnerability): string => $this->vulnerabilityLine($vulnerability, $severityThreshold),
+            $vulnerabilities,
+        );
+        $this->failingVulnerabilityCount = collect($vulnerabilities)
+            ->filter(fn (array $vulnerability): bool => $this->vulnerabilityFailsThreshold($vulnerability, $severityThreshold))
+            ->count();
+    }
+
+    public function exitCode(): int
+    {
+        return $this->failingVulnerabilityCount > 0 ? 1 : 0;
+    }
+
+    /** @return list<string> */
+    public function lines(): array
+    {
+        $lines = [
+            sprintf(
+                'Radar scan completed with %d vulnerability finding(s).',
+                $this->vulnerabilityCount,
+            ),
+            sprintf(
+                'CI severity threshold: %s. Failing vulnerability finding(s): %d.',
+                $this->severityThreshold,
+                $this->failingVulnerabilityCount,
+            ),
+        ];
+
+        if ($this->vulnerabilityCount === 0) {
+            return [
+                ...$lines,
+                'Radar scan passed. No vulnerabilities found.',
+            ];
+        }
+
+        $lines = [
+            ...$lines,
+            ...$this->vulnerabilityLines,
+        ];
+
+        if ($this->failingVulnerabilityCount === 0) {
+            $lines[] = sprintf(
+                'Radar scan passed. No vulnerabilities at %s severity or above.',
+                $this->severityThreshold,
+            );
+        }
+
+        return $lines;
+    }
+
+    /** @return list<array<string, mixed>> */
+    private function payloadList(RadarScan $scan, string $key): array
+    {
+        $value = $scan->payload[$key] ?? [];
+
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $items = [];
+
+        foreach ($value as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $typedItem = [];
+
+            foreach ($item as $itemKey => $itemValue) {
+                if (! is_string($itemKey)) {
+                    continue;
+                }
+
+                $typedItem[$itemKey] = $itemValue;
+            }
+
+            $items[] = $typedItem;
+        }
+
+        return $items;
+    }
+
+    /** @param array<string, mixed> $vulnerability */
+    private function vulnerabilityFailsThreshold(array $vulnerability, VulnerabilitySeverity $severityThreshold): bool
+    {
+        return $this->severity($vulnerability)->meetsThreshold($severityThreshold);
+    }
+
+    /** @param array<string, mixed> $vulnerability */
+    private function vulnerabilityLine(array $vulnerability, VulnerabilitySeverity $severityThreshold): string
+    {
+        $level = $this->vulnerabilityFailsThreshold($vulnerability, $severityThreshold) ? 'ERROR' : 'WARNING';
+
+        return sprintf('[%s] %s', $level, $this->vulnerabilityMessage($vulnerability));
+    }
+
+    /** @param array<string, mixed> $vulnerability */
+    private function severity(array $vulnerability): VulnerabilitySeverity
+    {
+        return VulnerabilitySeverity::fromAuditSeverity($this->stringValue($vulnerability, 'severity'));
+    }
+
+    /** @param array<string, mixed> $items */
+    private function stringValue(array $items, string $key): ?string
+    {
+        $value = $items[$key] ?? null;
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    /** @param array<string, mixed> $vulnerability */
+    private function vulnerabilityMessage(array $vulnerability): string
+    {
+        $packageName = $this->stringValue($vulnerability, 'package_name') ?? 'unknown package';
+        $severity = $this->severity($vulnerability)->value;
+        $message = sprintf('%s %s severity vulnerability found', $packageName, $severity);
+        $cve = $this->stringValue($vulnerability, 'cve');
+        $affectedVersions = $this->stringValue($vulnerability, 'affected_versions');
+        $suggestedCommand = $this->stringValue($vulnerability, 'suggested_command');
+
+        if ($cve !== null) {
+            $message = sprintf('%s. CVE: %s', $message, $cve);
+        }
+
+        if ($affectedVersions !== null) {
+            $message = sprintf('%s. Affected versions: %s', $message, $affectedVersions);
+        }
+
+        if ($suggestedCommand !== null) {
+            return sprintf('%s. Suggested command: %s', $message, $suggestedCommand);
+        }
+
+        return $message;
+    }
+}

--- a/tests/Commands/ScanCommandTest.php
+++ b/tests/Commands/ScanCommandTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\Artisan;
 use JoshDonnell\Radar\Models\RadarScan;
 
 it('stores a radar scan snapshot', function (): void {
@@ -62,4 +63,48 @@ it('fails clearly when the scan path does not exist', function (): void {
         ->expectsOutputToContain(sprintf('The path [%s] does not exist.', $basepath));
 
     expect(RadarScan::query()->count())->toBe(0);
+});
+
+it('emits generic CI output and fails when the severity threshold is met', function (): void {
+    $exitCode = Artisan::call('radar:scan', [
+        '--path' => __DIR__.'/../Fixtures',
+        '--ci' => true,
+        '--severity' => 'high',
+    ]);
+
+    expect($exitCode)->toBe(1)
+        ->and(Artisan::output())
+        ->toContain('Radar scan completed with 4 vulnerability finding(s).')
+        ->toContain('CI severity threshold: high. Failing vulnerability finding(s): 2.')
+        ->toContain('[ERROR] laravel/framework high severity vulnerability found. CVE: CVE-2026-1001')
+        ->toContain('[WARNING] symfony/console medium severity vulnerability found')
+        ->not->toContain('outdated package finding(s)')
+        ->not->toContain('abandoned package finding(s)');
+
+    expect(RadarScan::query()->count())->toBe(1);
+});
+
+it('passes CI mode when vulnerabilities are below the severity threshold', function (): void {
+    $exitCode = Artisan::call('radar:scan', [
+        '--path' => __DIR__.'/../Fixtures',
+        '--ci' => true,
+        '--severity' => 'critical',
+    ]);
+
+    expect($exitCode)->toBe(0)
+        ->and(Artisan::output())
+        ->toContain('CI severity threshold: critical. Failing vulnerability finding(s): 0.')
+        ->toContain('Radar scan passed. No vulnerabilities at critical severity or above.');
+});
+
+it('validates CI severity options before scanning', function (): void {
+    $exitCode = Artisan::call('radar:scan', [
+        '--path' => __DIR__.'/../Fixtures',
+        '--ci' => true,
+        '--severity' => 'unknown',
+    ]);
+
+    expect($exitCode)->toBe(2)
+        ->and(Artisan::output())->toContain('Unsupported CI severity threshold')
+        ->and(RadarScan::query()->count())->toBe(0);
 });

--- a/tests/Enums/VulnerabilitySeverityTest.php
+++ b/tests/Enums/VulnerabilitySeverityTest.php
@@ -13,3 +13,18 @@ it('maps audit severity labels to vulnerability severities', function (): void {
         ->and(VulnerabilitySeverity::fromAuditSeverity(null))->toBe(VulnerabilitySeverity::Unknown)
         ->and(VulnerabilitySeverity::fromAuditSeverity('unknown-value'))->toBe(VulnerabilitySeverity::Unknown);
 });
+
+it('maps threshold labels to vulnerability severities', function (): void {
+    expect(VulnerabilitySeverity::fromThreshold('low'))->toBe(VulnerabilitySeverity::Low)
+        ->and(VulnerabilitySeverity::fromThreshold('medium'))->toBe(VulnerabilitySeverity::Medium)
+        ->and(VulnerabilitySeverity::fromThreshold('high'))->toBe(VulnerabilitySeverity::High)
+        ->and(VulnerabilitySeverity::fromThreshold('critical'))->toBe(VulnerabilitySeverity::Critical)
+        ->and(VulnerabilitySeverity::fromThreshold('unknown'))->toBeNull();
+});
+
+it('compares severity thresholds', function (): void {
+    expect(VulnerabilitySeverity::Critical->meetsThreshold(VulnerabilitySeverity::High))->toBeTrue()
+        ->and(VulnerabilitySeverity::High->meetsThreshold(VulnerabilitySeverity::High))->toBeTrue()
+        ->and(VulnerabilitySeverity::Medium->meetsThreshold(VulnerabilitySeverity::High))->toBeFalse()
+        ->and(VulnerabilitySeverity::Unknown->meetsThreshold(VulnerabilitySeverity::Low))->toBeFalse();
+});


### PR DESCRIPTION
This PR adds:

- A new CI command for use on GH Actions and other CI runners
- Allows the user to set a `severity` flag for what level should cause the CI to fail
- The CI will showcase the vulnerability and it's relevant CVE in the error